### PR TITLE
Adding support for older CUDA 11.5 driver levels.

### DIFF
--- a/Dockerfile.cuda-11.5
+++ b/Dockerfile.cuda-11.5
@@ -1,0 +1,53 @@
+FROM mambaorg/micromamba:1.3.1-jammy
+# TODO: For CUDA/GPU integration
+# FROM mambaorg/micromamba:1.3.1-jammy-cuda-11.7.1
+LABEL MAINTAINER="Josh Rhoades <josh@axds.co>"
+
+ENV MODEL_DIRECTORY /models
+ENV OUTPUT_DIRECTORY /outputs
+ENV APP_DIRECTORY /app
+
+ENV PROMETHEUS_MULTIPROC_DIR /tmp/metrics
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+        libgl1 \
+        libglib2.0-0 \
+        libegl-dev \
+        libsm6 \
+        libxext6 \
+        libxrender1 \
+        libpng-dev \
+        libjpeg-dev \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    mkdir ${APP_DIRECTORY} && \
+    chown mambauser:mambauser ${APP_DIRECTORY} && \
+    mkdir ${OUTPUT_DIRECTORY} && \
+    chown mambauser:mambauser ${OUTPUT_DIRECTORY} && \
+    mkdir ${PROMETHEUS_MULTIPROC_DIR} && \
+    chown mambauser:mambauser ${PROMETHEUS_MULTIPROC_DIR}
+
+COPY --chown=mambauser:mambauser environment.cuda-11.5.yml /tmp/environment.yml
+RUN --mount=type=cache,id=rip_current_detection,target=/opt/conda/pkgs \
+    --mount=type=cache,id=rip_current_detection,target=/root/.cache/pip \
+    micromamba install -c conda-forge --name base --yes --file /tmp/environment.yml && \
+    micromamba clean --all --yes
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+ENV PATH "$MAMBA_ROOT_PREFIX/bin:$PATH"
+
+# Copy Python app files
+COPY --chown=mambauser:mambauser *.py /app/
+
+# Copy container-specific configuration
+COPY --chown=mambauser:mambauser docker /docker/
+RUN chmod u+x /docker/scripts/expire-annotated-images.sh
+
+# Copy models
+COPY --chown=mambauser:mambauser models /models/
+
+WORKDIR /app
+CMD ["gunicorn", "api:app", "--config", "/docker/api/gunicorn.conf.py"]

--- a/api.py
+++ b/api.py
@@ -114,7 +114,7 @@ def load_model(model_path):
     model.to(the_device)
     model.eval()
 
-    model.share_memory()
+    # model.share_memory()
 
     return model
 

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -39,3 +39,40 @@ services:
         --access-logfile -
         --error-logfile -
         -k worker.LimitedConcurrencyUvicornWorker
+
+  api-cuda-11-5:
+    image: rip-current-detection:cuda11-5
+    profiles: [ "cuda11-5" ]
+    build:
+      context:      .
+      dockerfile:   Dockerfile.cuda-11.5
+    ports:
+     - 8888:8000
+    tmpfs:
+     - "/outputs"
+    environment:
+     - OUTPUT_DIRECTORY=/outputs
+    volumes:
+      - "model-data:/root/.cache/torch:rw"
+    # Optional: nvidia GPU hardware support
+    runtime: 'nvidia'
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            capabilities: [
+              # 'gpu',
+              'compute',
+              # 'video',
+              'utility'
+            ]
+            count: 1
+    command: >
+      gunicorn api:app
+        --bind "0.0.0.0:8000"
+        --timeout 240
+        -w 1 --max-requests 10000
+        --access-logfile -
+        --error-logfile -
+        -k worker.LimitedConcurrencyUvicornWorker

--- a/environment.cuda-11.5.yml
+++ b/environment.cuda-11.5.yml
@@ -1,0 +1,33 @@
+name: rip_current_detection
+channels:
+  # - pytorch
+  # - nvidia
+  - conda-forge
+  - defaults
+dependencies:
+  # Python
+  - conda-forge::python=3.9
+  # Model/ML-related
+  - conda-forge::numpy=1.23.3
+  - conda-forge::opencv=4.6.0
+  # - pytorch::pytorch=1.13.1
+  # - pytorch::pytorch-cuda=12.1
+  # - pytorch::torchvision=0.14.1
+  # TODO: matplotlib may be unused
+  # - matplotlib=3.8.2
+  # API related
+  - conda-forge::fastapi
+  - conda-forge::gunicorn
+  - conda-forge::python-multipart
+  - conda-forge::uvicorn
+  - conda-forge::filetype
+  # TODO: PIL/Pillow may be unused?
+  # - Pillow==9.4.0
+  # Testing/code quality
+  - conda-forge::flake8>=3.7.9
+  # Pip
+  - conda-forge::pip
+  - pip:
+    - starlette_exporter>=0.21.0,<0.22
+    - torch==1.12 --index-url https://download.pytorch.org/whl/cu115
+    - torchvision==0.13.0 --index-url https://download.pytorch.org/whl/cu115


### PR DESCRIPTION
Supporting older server CUDA deployments (11.4+), adding new environment builds for older torch (1.12) / torchvision (0.13.0) versions that maintain support for 11.4+ CUDA driver versions.

Pytorch Compatibility Matrix Reference: <https://github.com/pytorch/pytorch/blob/main/RELEASE.md>