### PR TITLE
Model prediction timing metric

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -4,7 +4,8 @@ from prometheus_client import (
     make_asgi_app,
     CollectorRegistry,
     multiprocess,
-    Counter
+    Counter,
+    Histogram
 )
 from model_version import (
     ModelFramework,
@@ -12,6 +13,19 @@ from model_version import (
     TorchvisionModelVersion,
 )
 
+
+MODEL_PREDICTION_TIMING_HISTOGRAM = Histogram(
+    'model_prediction_timing_histogram',
+    'Histogram',
+    labelnames = [
+        'model_framework',
+        'model_name',
+        'model_version',
+    ],
+    buckets = (
+        0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0, 10, float("inf")
+    )
+)
 
 OBJECT_CLASSIFICATION_DETECTION_COUNTER = Counter(
     'object_classification_detection_counter',
@@ -100,3 +114,14 @@ def increment_rip_current_object_counter(
         mdl_version,
         __RIP_CURRENT
     ).inc()
+
+def time_model_prediction_context(
+    fw: str,
+    mdl_name: str,
+    mdl_version: str
+):
+    return MODEL_PREDICTION_TIMING_HISTOGRAM.labels(
+        fw,
+        mdl_name,
+        mdl_version,
+    ).time()

--- a/torchvision_processing.py
+++ b/torchvision_processing.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from typing import Any, List, Tuple, Union
 from model_version import ModelFramework, TorchvisionModelName, TorchvisionModelVersion
 from score import BoundingBoxPoint, ClassificationModelResult
-from metrics import increment_rip_current_detection_counter, increment_rip_current_object_counter
+from metrics import (
+    increment_rip_current_detection_counter,
+    increment_rip_current_object_counter,
+    time_model_prediction_context
+)
 
 
 logger = logging.getLogger( __name__ )
@@ -205,7 +209,18 @@ def torchvision_process_image(
     # Convert the input image from BGR to RGB
     input_image = cv2.cvtColor(input_image, cv2.COLOR_BGR2RGB)
 
-    boxes = get_boxes( input_image, pt_model, THRESHOLD )
+    boxes = None
+
+    labels: list = [
+        ModelFramework.ULTRALYTICS.value,
+        model,
+        version
+    ]
+
+    with time_model_prediction_context( *labels ):
+
+        boxes = get_boxes( input_image, pt_model, THRESHOLD )
+
 
     detected = False
 

--- a/ultralytics_processing.py
+++ b/ultralytics_processing.py
@@ -10,7 +10,11 @@ from model_version import (
     YOLOModelName,
     YOLOModelVersion
 )
-from metrics import increment_rip_current_detection_counter, increment_rip_current_object_counter
+from metrics import (
+    increment_rip_current_detection_counter,
+    increment_rip_current_object_counter,
+    time_model_prediction_context
+)
 import logging
 import torch
 
@@ -113,12 +117,22 @@ def yolo_process_image(
 
     img_boxes = frame
 
-    #use YOLOv8
-    results = yolo_model.predict(
-        frame,
-        # conf = 0.1,
-        device = get_device()
-    )
+    results = None
+
+    labels: list = [
+        ModelFramework.ULTRALYTICS.value,
+        model,
+        version
+    ]
+
+    with time_model_prediction_context( *labels ):
+
+        #use YOLOv8
+        results = yolo_model.predict(
+            frame,
+            # conf = 0.1,
+            device = get_device()
+        )
 
     # If any score is above threshold, flag it as detected
     detected = False


### PR DESCRIPTION
Add a metric specifically timing the model prediction part of a request (apart from the overall timing of the request tracked elsewhere)